### PR TITLE
refactor: EmojiCard에서 다운로드 로딩 스피너 제거

### DIFF
--- a/src/components/emoji/EmojiCard.tsx
+++ b/src/components/emoji/EmojiCard.tsx
@@ -1,11 +1,10 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo } from "react";
 
 import Image from "next/image";
 
 import debounce from "lodash.debounce";
-import { Loader2 } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 
@@ -13,12 +12,10 @@ import type { Emoji, PopularEmoji } from "@/types/database";
 
 type EmojiCardProps = {
   emoji: Emoji | PopularEmoji;
-  onDownload?: (emoji: Emoji | PopularEmoji) => Promise<void>;
+  onDownload?: (emoji: Emoji | PopularEmoji) => void;
 };
 
 export const EmojiCard = ({ emoji, onDownload }: EmojiCardProps) => {
-  const [isDownloading, setIsDownloading] = useState(false);
-
   // Debounced click tracking
   const trackClick = useMemo(
     () =>
@@ -36,54 +33,36 @@ export const EmojiCard = ({ emoji, onDownload }: EmojiCardProps) => {
     []
   );
 
-  const handleClick = useCallback(async () => {
-    if (isDownloading) return;
-
-    setIsDownloading(true);
-
+  const handleClick = useCallback(() => {
     // Track click (debounced)
     trackClick(emoji.slug);
 
-    try {
-      if (onDownload) {
-        await onDownload(emoji);
-      } else {
-        await downloadEmoji(emoji);
-      }
-    } catch (error) {
-      console.error("Download failed:", error);
-    } finally {
-      setIsDownloading(false);
+    if (onDownload) {
+      onDownload(emoji);
+    } else {
+      downloadEmoji(emoji);
     }
-  }, [emoji, isDownloading, onDownload, trackClick]);
+  }, [emoji, onDownload, trackClick]);
 
   return (
     <button
       onClick={handleClick}
-      disabled={isDownloading}
       className={cn(
         "group relative flex flex-col items-center justify-center",
         "rounded-lg p-3 transition-all",
         "hover:bg-muted",
-        "focus:ring-primary focus:ring-2 focus:ring-offset-2 focus:outline-none",
-        "disabled:cursor-not-allowed disabled:opacity-50"
+        "focus:ring-primary focus:ring-2 focus:ring-offset-2 focus:outline-none"
       )}
     >
       {/* Emoji Image */}
       <div className="relative h-12 w-12 sm:h-16 sm:w-16">
-        {isDownloading ? (
-          <div className="flex h-full w-full items-center justify-center">
-            <Loader2 className="text-muted-foreground h-6 w-6 animate-spin" />
-          </div>
-        ) : (
-          <Image
-            src={emoji.image_url}
-            alt={emoji.name}
-            fill
-            className="object-contain"
-            unoptimized={emoji.is_animated}
-          />
-        )}
+        <Image
+          src={emoji.image_url}
+          alt={emoji.name}
+          fill
+          className="object-contain"
+          unoptimized={emoji.is_animated}
+        />
       </div>
 
       {/* Emoji Name */}


### PR DESCRIPTION
## Summary
- EmojiCard 컴포넌트에서 불필요한 다운로드 로딩 스피너 제거
- `isDownloading` 상태 및 관련 로직 제거
- `onDownload` 타입을 `Promise<void>`에서 `void`로 변경

## Test plan
- [ ] 이모지 클릭 시 즉시 다운로드 시작 확인
- [ ] 로딩 스피너 없이 이미지가 항상 표시되는지 확인

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)