### PR TITLE
chore: 에이전트 상태 폴더 gitignore 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,10 @@ yarn-error.log*
 # env files (can opt-in for committing if needed)
 .env*
 
+# agent state
+.bkit/
+.omc/
+
 # vercel
 .vercel
 


### PR DESCRIPTION
## Summary
- `.bkit/`, `.omc/` 에이전트 상태 폴더를 `.gitignore`에 추가

## Related Issue
Closes #17

## Changes
| 파일 | 변경 |
|------|------|
| `.gitignore` | `.bkit/`, `.omc/` 패턴 추가 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)