### PR TITLE
fix(emoji): hover tooltip 뷰포트 하단 짤림 수정

### DIFF
--- a/src/components/emoji/EmojiCard.tsx
+++ b/src/components/emoji/EmojiCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useRef, useState } from "react";
 
 import Image from "next/image";
 
@@ -12,17 +12,30 @@ import { useEmojiDownload } from "@/hooks";
 
 type EmojiCardProps = {
   emoji: Emoji | PopularEmoji;
-  tooltipDirection?: "top" | "bottom";
 };
 
-export const EmojiCard = ({ emoji, tooltipDirection = "top" }: EmojiCardProps) => {
+const TOOLTIP_HEIGHT = 160; // approximate tooltip height (image 96px + padding + text)
+
+export const EmojiCard = ({ emoji }: EmojiCardProps) => {
   const { handleDownload } = useEmojiDownload(emoji);
   const [hovered, setHovered] = useState(false);
+  const [direction, setDirection] = useState<"top" | "bottom">("bottom");
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  const handleMouseEnter = useCallback(() => {
+    if (buttonRef.current) {
+      const rect = buttonRef.current.getBoundingClientRect();
+      const spaceBelow = window.innerHeight - rect.bottom;
+      setDirection(spaceBelow < TOOLTIP_HEIGHT ? "top" : "bottom");
+    }
+    setHovered(true);
+  }, []);
 
   return (
     <button
+      ref={buttonRef}
       onClick={handleDownload}
-      onMouseEnter={() => setHovered(true)}
+      onMouseEnter={handleMouseEnter}
       onMouseLeave={() => setHovered(false)}
       className={cn(
         "group relative flex cursor-pointer items-center gap-3",
@@ -42,13 +55,13 @@ export const EmojiCard = ({ emoji, tooltipDirection = "top" }: EmojiCardProps) =
       </div>
       <span className="truncate text-sm">:{emoji.name}</span>
 
-      {/* Hover tooltip - only render image when hovered */}
+      {/* Hover tooltip - direction based on viewport position */}
       {hovered && (
         <div
           className={cn(
             "pointer-events-none absolute left-1/2 z-50 -translate-x-1/2",
             "animate-in fade-in zoom-in-95 duration-200",
-            tooltipDirection === "top" ? "bottom-full mb-2" : "top-full mt-2"
+            direction === "top" ? "bottom-full mb-2" : "top-full mt-2"
           )}
         >
           <div className="bg-popover ring-border flex flex-col items-center gap-1.5 rounded-lg px-4 py-3 shadow-lg ring-1">

--- a/src/components/emoji/EmojiGrid.tsx
+++ b/src/components/emoji/EmojiGrid.tsx
@@ -27,16 +27,10 @@ export const EmojiGrid = ({ emojis, className, columns = "auto" }: EmojiGridProp
     );
   }
 
-  const colCount = columns === "auto" ? 5 : columns;
-
   return (
     <div className={cn("grid gap-2", gridCols[columns], className)}>
-      {emojis.map((emoji, index) => (
-        <EmojiCard
-          key={emoji.id}
-          emoji={emoji}
-          tooltipDirection={index < colCount ? "bottom" : "top"}
-        />
+      {emojis.map((emoji) => (
+        <EmojiCard key={emoji.id} emoji={emoji} />
       ))}
     </div>
   );


### PR DESCRIPTION
## Summary
- 이모지 카드 hover tooltip이 페이지 하단에서 짤리는 문제 수정
- 뷰포트 위치 기반으로 tooltip 방향을 동적으로 결정

## Related Issue
Closes #25

## Changes
| 그룹 | 파일 | 변경 |
|------|------|------|
| 컴포넌트 | EmojiCard.tsx | tooltipDirection prop 제거, hover 시 getBoundingClientRect로 뷰포트 하단 여유 공간 체크하여 방향 동적 결정 |
| 컴포넌트 | EmojiGrid.tsx | tooltip 방향 관련 정적 로직 제거 |

## Test
- [ ] 페이지 상단 이모지 hover → tooltip 아래로 표시
- [ ] 페이지 하단 이모지 hover → tooltip 위로 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)