### PR TITLE
style(branding): Slack Emo 브랜딩 통일 및 Footer 제거

### DIFF
--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -5,7 +5,7 @@ test.describe("Homepage", () => {
     await page.goto("/");
 
     // Logo should be visible in header
-    await expect(page.getByRole("banner").getByRole("link", { name: /slack-emo/i })).toBeVisible();
+    await expect(page.getByRole("banner").getByRole("link", { name: /Slack Emo/i })).toBeVisible();
 
     // Search input should be visible (desktop)
     await expect(page.getByPlaceholder("Search emojis...")).toBeVisible();
@@ -52,7 +52,7 @@ test.describe("Homepage", () => {
   test("should display footer", async ({ page }) => {
     await page.goto("/");
 
-    await expect(page.getByText(/slack-emo/).last()).toBeVisible();
+    await expect(page.getByText(/Slack Emo/).last()).toBeVisible();
     await expect(page.getByText(/2026/)).toBeVisible();
   });
 
@@ -61,7 +61,7 @@ test.describe("Homepage", () => {
 
     await page
       .getByRole("banner")
-      .getByRole("link", { name: /slack-emo/i })
+      .getByRole("link", { name: /Slack Emo/i })
       .click();
 
     await expect(page).toHaveURL("/");

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
-  "name": "slack-emo",
-  "short_name": "slack-emo",
-  "description": "슬랙 커스텀 이모지 디렉토리",
+  "name": "Slack Emo",
+  "short_name": "Slack Emo",
+  "description": "Slack Emo",
   "start_url": "/",
   "display": "standalone",
   "background_color": "#ffffff",

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,4 +1,4 @@
-import { Footer, Header } from "@/components/layout";
+import { Header } from "@/components/layout";
 import { SearchProvider } from "@/components/search-provider";
 
 export default function MainLayout({
@@ -11,7 +11,6 @@ export default function MainLayout({
       <div className="bg-background flex min-h-screen flex-col">
         <Header />
         <main className="flex-1">{children}</main>
-        <Footer />
       </div>
     </SearchProvider>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,23 +13,19 @@ const notoSansKR = Noto_Sans_KR({
 
 export const metadata: Metadata = {
   title: {
-    default: "Slack Emo — 슬랙 커스텀 이모지 디렉토리",
+    default: "Slack Emo",
     template: "%s | Slack Emo",
   },
-  description:
-    "슬랙에서 사용할 수 있는 커스텀 이모지를 검색하고 다운로드하세요. 누구나 이모지를 업로드하고 공유할 수 있습니다.",
   manifest: "/manifest.json",
   openGraph: {
-    title: "Slack Emo — 슬랙 커스텀 이모지 디렉토리",
-    description: "슬랙에서 사용할 수 있는 커스텀 이모지를 검색하고 다운로드하세요.",
+    title: "Slack Emo",
     type: "website",
     locale: "ko_KR",
     siteName: "Slack Emo",
   },
   twitter: {
     card: "summary_large_image",
-    title: "Slack Emo — 슬랙 커스텀 이모지 디렉토리",
-    description: "슬랙에서 사용할 수 있는 커스텀 이모지를 검색하고 다운로드하세요.",
+    title: "Slack Emo",
   },
   icons: {
     icon: "/favicon.ico",

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -5,9 +5,9 @@ export const Footer = () => (
     <div className="container mx-auto max-w-6xl px-4 py-6">
       <div className="flex flex-col items-center justify-between gap-4 md:flex-row">
         <Link href="/" className="font-bold">
-          slack-emo
+          Slack Emo
         </Link>
-        <p className="text-muted-foreground text-sm">&copy; {new Date().getFullYear()} slack-emo</p>
+        <p className="text-muted-foreground text-sm">&copy; {new Date().getFullYear()} Slack Emo</p>
       </div>
     </div>
   </footer>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -29,7 +29,7 @@ export const Header = () => {
       <div className="container mx-auto flex h-16 max-w-6xl items-center justify-between px-4">
         {/* Logo */}
         <Link href="/" className="flex items-center gap-2">
-          <span className="text-xl font-bold">slack-emo</span>
+          <span className="text-xl font-bold">Slack Emo</span>
         </Link>
 
         {/* Search - Desktop */}


### PR DESCRIPTION
## Summary
- 프로젝트 제목 slack-emo → Slack Emo 통일
- 메타데이터 한국어 설명 텍스트 제거
- 메인 레이아웃에서 Footer 제거

## Related Issue
Closes #27

## Changes
| 그룹 | 파일 | 변경 |
|------|------|------|
| 레이아웃 | Header.tsx, Footer.tsx, (main)/layout.tsx | 브랜딩 변경, Footer 제거 |
| 메타 | layout.tsx, manifest.json | 제목 통일, 설명 제거 |
| 테스트 | home.spec.ts | 매칭 텍스트 업데이트 |

## Test
- [ ] 헤더 로고 "Slack Emo" 표시 확인
- [ ] Footer 미표시 확인
- [ ] PWA manifest 정상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)