### PR TITLE
fix(emoji): 모바일 터치 시 다운로드 동작 수정

### DIFF
--- a/src/components/emoji/EmojiCard.tsx
+++ b/src/components/emoji/EmojiCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useRef, useState, useSyncExternalStore } from "react";
 
 import Image from "next/image";
 
@@ -14,29 +14,41 @@ type EmojiCardProps = {
   emoji: Emoji | PopularEmoji;
 };
 
-const TOOLTIP_HEIGHT = 160; // approximate tooltip height (image 96px + padding + text)
+const TOOLTIP_HEIGHT = 160;
+
+const getIsTouchDevice = () => "ontouchstart" in window || navigator.maxTouchPoints > 0;
+const subscribeToNothing = () => () => {};
+const useIsTouchDevice = () =>
+  useSyncExternalStore(subscribeToNothing, getIsTouchDevice, () => false);
 
 export const EmojiCard = ({ emoji }: EmojiCardProps) => {
   const { handleDownload } = useEmojiDownload(emoji);
   const [hovered, setHovered] = useState(false);
   const [direction, setDirection] = useState<"top" | "bottom">("bottom");
   const buttonRef = useRef<HTMLButtonElement>(null);
+  const isTouch = useIsTouchDevice();
 
   const handleMouseEnter = useCallback(() => {
+    if (isTouch) return;
     if (buttonRef.current) {
       const rect = buttonRef.current.getBoundingClientRect();
       const spaceBelow = window.innerHeight - rect.bottom;
       setDirection(spaceBelow < TOOLTIP_HEIGHT ? "top" : "bottom");
     }
     setHovered(true);
-  }, []);
+  }, [isTouch]);
+
+  const handleMouseLeave = useCallback(() => {
+    if (isTouch) return;
+    setHovered(false);
+  }, [isTouch]);
 
   return (
     <button
       ref={buttonRef}
       onClick={handleDownload}
       onMouseEnter={handleMouseEnter}
-      onMouseLeave={() => setHovered(false)}
+      onMouseLeave={handleMouseLeave}
       className={cn(
         "group relative flex cursor-pointer items-center gap-3",
         "border-border rounded-md border px-3 py-2.5 transition-all",
@@ -55,8 +67,8 @@ export const EmojiCard = ({ emoji }: EmojiCardProps) => {
       </div>
       <span className="truncate text-sm">:{emoji.name}</span>
 
-      {/* Hover tooltip - direction based on viewport position */}
-      {hovered && (
+      {/* Hover tooltip - desktop only */}
+      {hovered && !isTouch && (
         <div
           className={cn(
             "pointer-events-none absolute left-1/2 z-50 -translate-x-1/2",


### PR DESCRIPTION
## Summary
- 모바일 터치 시 hover tooltip 대신 즉시 다운로드 동작하도록 수정
- useSyncExternalStore로 터치 디바이스 감지 (ESLint 호환)

## Related Issue
Closes #33

## Changes
| 그룹 | 파일 | 변경 |
|------|------|------|
| 컴포넌트 | EmojiCard.tsx | 터치 디바이스 감지, tooltip 조건부 렌더링 |

## Test
- [x] Playwright 모바일(375x812) 탭 → 다운로드 성공 확인
- [x] Playwright 데스크톱(1280x800) hover → tooltip 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)