### PR TITLE
feat(analytics): Vercel Web Analytics 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@supabase/supabase-js": "^2.90.1",
         "@tanstack/react-query": "^5.90.16",
         "@types/lodash.debounce": "^4.0.9",
+        "@vercel/analytics": "^1.6.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
@@ -6059,6 +6060,44 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.6.1.tgz",
+      "integrity": "sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg==",
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@supabase/supabase-js": "^2.90.1",
     "@tanstack/react-query": "^5.90.16",
     "@types/lodash.debounce": "^4.0.9",
+    "@vercel/analytics": "^1.6.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata, Viewport } from "next";
 import { Noto_Sans_KR } from "next/font/google";
 
+import { Analytics } from "@vercel/analytics/react";
+
 import { QueryProvider, ThemeProvider, Toaster } from "@/components";
 
 import "./globals.css";
@@ -63,6 +65,7 @@ export default function RootLayout({
           >
             {children}
             <Toaster position="top-center" richColors />
+            <Analytics />
           </ThemeProvider>
         </QueryProvider>
       </body>


### PR DESCRIPTION
## Summary
- @vercel/analytics 패키지 추가
- RootLayout에 `<Analytics />` 컴포넌트 적용하여 페이지뷰/방문자 수집 활성화

## Related Issue
Closes #35

## Changes
| 그룹 | 파일 | 변경 |
|------|------|------|
| 설정 | package.json, package-lock.json | @vercel/analytics 의존성 추가 |
| UI | src/app/layout.tsx | Analytics 컴포넌트 import 및 렌더링 |

## Test
- [x] `npm run build` 통과
- [ ] Vercel 배포 후 Analytics 대시보드 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)