### PR TITLE
fix(emoji): 다운로드/업로드 시 Slack 이모지 규격 최적화 (128x128, 128KB)

### DIFF
--- a/src/hooks/use-emoji-download.ts
+++ b/src/hooks/use-emoji-download.ts
@@ -3,6 +3,9 @@
 import { useCallback, useMemo } from "react";
 
 import debounce from "lodash.debounce";
+import { toast } from "sonner";
+
+import { optimizeForSlack } from "@/lib/optimize-for-slack";
 
 import type { Emoji, PopularEmoji } from "@/types/database";
 
@@ -10,9 +13,17 @@ const downloadEmoji = async (emoji: Emoji | PopularEmoji) => {
   const response = await fetch(emoji.image_url);
   const blob = await response.blob();
 
+  const { blob: optimized, extension, skipped } = await optimizeForSlack(blob);
+
+  if (skipped) {
+    toast.warning("GIF 용량이 128KB를 초과합니다. 원본으로 다운로드됩니다.", {
+      description: "Slack 업로드 시 용량 제한에 걸릴 수 있습니다.",
+    });
+  }
+
   const link = document.createElement("a");
-  link.href = URL.createObjectURL(blob);
-  link.download = `${emoji.name}.${emoji.is_animated ? "gif" : "png"}`;
+  link.href = URL.createObjectURL(optimized);
+  link.download = `${emoji.name}.${extension}`;
   link.click();
 
   URL.revokeObjectURL(link.href);

--- a/src/lib/optimize-for-slack.ts
+++ b/src/lib/optimize-for-slack.ts
@@ -1,0 +1,63 @@
+const SLACK_EMOJI_SIZE = 128;
+const SLACK_MAX_BYTES = 128 * 1024; // 128KB
+
+/**
+ * 다운로드 시 이미지를 Slack 이모지 규격(128x128, 128KB 이하)으로 최적화합니다.
+ * - PNG/JPEG/WebP: Canvas로 128x128 리사이즈 → 128KB 초과 시 quality 단계적 압축
+ * - GIF: 128KB 이하면 원본, 초과 시 null 반환 (호출부에서 처리)
+ */
+export const optimizeForSlack = async (
+  blob: Blob
+): Promise<{ blob: Blob; extension: string; skipped?: boolean }> => {
+  // GIF는 클라이언트에서 프레임 단위 리사이즈가 어려우므로
+  // 용량만 체크하고, 초과 시 skipped 플래그로 알림
+  if (blob.type === "image/gif") {
+    if (blob.size <= SLACK_MAX_BYTES) {
+      return { blob, extension: "gif" };
+    }
+    return { blob, extension: "gif", skipped: true };
+  }
+
+  // PNG/JPEG/WebP → 128x128 리사이즈
+  const bitmap = await createImageBitmap(blob);
+  try {
+    const canvas = new OffscreenCanvas(SLACK_EMOJI_SIZE, SLACK_EMOJI_SIZE);
+    const ctx = canvas.getContext("2d")!;
+
+    const scale = Math.min(SLACK_EMOJI_SIZE / bitmap.width, SLACK_EMOJI_SIZE / bitmap.height);
+    const w = bitmap.width * scale;
+    const h = bitmap.height * scale;
+    const x = (SLACK_EMOJI_SIZE - w) / 2;
+    const y = (SLACK_EMOJI_SIZE - h) / 2;
+
+    // 투명 배경 유지를 위해 clear
+    ctx.clearRect(0, 0, SLACK_EMOJI_SIZE, SLACK_EMOJI_SIZE);
+    ctx.drawImage(bitmap, x, y, w, h);
+
+    // 1차: PNG로 시도 (투명 배경 유지)
+    const pngBlob = await canvas.convertToBlob({ type: "image/png" });
+    if (pngBlob.size <= SLACK_MAX_BYTES) {
+      return { blob: pngBlob, extension: "png" };
+    }
+
+    // 2차: WebP quality를 단계적으로 낮춰 128KB 이하 달성
+    for (const quality of [0.9, 0.8, 0.7, 0.5, 0.3]) {
+      const webpBlob = await canvas.convertToBlob({
+        type: "image/webp",
+        quality,
+      });
+      if (webpBlob.size <= SLACK_MAX_BYTES) {
+        return { blob: webpBlob, extension: "webp" };
+      }
+    }
+
+    // 3차: JPEG 최저 quality (투명 배경은 손실되지만 용량 확보)
+    const jpegBlob = await canvas.convertToBlob({
+      type: "image/jpeg",
+      quality: 0.3,
+    });
+    return { blob: jpegBlob, extension: "jpg" };
+  } finally {
+    bitmap.close();
+  }
+};

--- a/src/lib/resize-image.ts
+++ b/src/lib/resize-image.ts
@@ -1,9 +1,10 @@
 const EMOJI_SIZE = 128;
+const SLACK_MAX_BYTES = 128 * 1024; // 128KB
 
 /**
- * 클라이언트에서 이미지를 128x128로 리사이즈합니다.
+ * 클라이언트에서 이미지를 128x128, 128KB 이하로 리사이즈합니다.
  * - GIF: 애니메이션 프레임 유지를 위해 리사이즈 없이 원본 반환
- * - 그 외: Canvas API로 128x128 PNG 변환
+ * - 그 외: Canvas API로 128x128 변환 → 128KB 초과 시 quality 단계적 압축
  */
 export const resizeImageFile = async (file: File): Promise<File> => {
   if (file.type === "image/gif") {
@@ -21,11 +22,31 @@ export const resizeImageFile = async (file: File): Promise<File> => {
     const x = (EMOJI_SIZE - w) / 2;
     const y = (EMOJI_SIZE - h) / 2;
 
+    ctx.clearRect(0, 0, EMOJI_SIZE, EMOJI_SIZE);
     ctx.drawImage(bitmap, x, y, w, h);
 
-    const blob = await canvas.convertToBlob({ type: "image/png" });
-    return new File([blob], file.name.replace(/\.\w+$/, ".png"), {
-      type: "image/png",
+    // 1차: PNG (투명 배경 유지)
+    const pngBlob = await canvas.convertToBlob({ type: "image/png" });
+    if (pngBlob.size <= SLACK_MAX_BYTES) {
+      return new File([pngBlob], file.name.replace(/\.\w+$/, ".png"), {
+        type: "image/png",
+      });
+    }
+
+    // 2차: WebP quality 단계적 압축
+    for (const quality of [0.9, 0.8, 0.7, 0.5, 0.3]) {
+      const webpBlob = await canvas.convertToBlob({ type: "image/webp", quality });
+      if (webpBlob.size <= SLACK_MAX_BYTES) {
+        return new File([webpBlob], file.name.replace(/\.\w+$/, ".webp"), {
+          type: "image/webp",
+        });
+      }
+    }
+
+    // 3차: JPEG 최저 quality
+    const jpegBlob = await canvas.convertToBlob({ type: "image/jpeg", quality: 0.3 });
+    return new File([jpegBlob], file.name.replace(/\.\w+$/, ".jpg"), {
+      type: "image/jpeg",
     });
   } finally {
     bitmap.close();


### PR DESCRIPTION
## Summary
- 다운로드 시 이미지를 Slack 이모지 규격(128x128px, 128KB 이하)으로 자동 최적화
- 업로드 시에도 128KB 용량 제한 적용하여 Slack 호환성 보장
- PNG → WebP → JPEG 단계적 압축으로 용량 초과 방지
- GIF 128KB 초과 시 toast 경고 표시

## Related Issue
Closes #37
Closes #38

## Changes
| 파일 | 변경 |
|------|------|
| src/lib/optimize-for-slack.ts | 다운로드용 Slack 최적화 유틸 신규 생성 |
| src/lib/resize-image.ts | 업로드 시 128KB 용량 제한 추가 |
| src/hooks/use-emoji-download.ts | 다운로드 시 optimizeForSlack 적용 |

## Test
- [ ] PNG 이모지 다운로드 시 128x128, 128KB 이하 확인
- [ ] 큰 용량 PNG 업로드 시 압축 동작 확인
- [ ] GIF 128KB 초과 시 경고 toast 표시 확인
- [ ] 기존 이모지 업로드/다운로드 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)