### PR TITLE
feat(emoji): GIF 다운로드 시 FFmpeg 리사이즈 최적화 (#40)

### DIFF
--- a/src/hooks/use-emoji-download.ts
+++ b/src/hooks/use-emoji-download.ts
@@ -3,7 +3,6 @@
 import { useCallback, useMemo } from "react";
 
 import debounce from "lodash.debounce";
-import { toast } from "sonner";
 
 import { optimizeForSlack } from "@/lib/optimize-for-slack";
 
@@ -13,13 +12,7 @@ const downloadEmoji = async (emoji: Emoji | PopularEmoji) => {
   const response = await fetch(emoji.image_url);
   const blob = await response.blob();
 
-  const { blob: optimized, extension, skipped } = await optimizeForSlack(blob);
-
-  if (skipped) {
-    toast.warning("GIF 용량이 128KB를 초과합니다. 원본으로 다운로드됩니다.", {
-      description: "Slack 업로드 시 용량 제한에 걸릴 수 있습니다.",
-    });
-  }
+  const { blob: optimized, extension } = await optimizeForSlack(blob);
 
   const link = document.createElement("a");
   link.href = URL.createObjectURL(optimized);

--- a/src/lib/optimize-for-slack.ts
+++ b/src/lib/optimize-for-slack.ts
@@ -1,21 +1,64 @@
+import { getFFmpeg } from "@/lib/video-to-gif";
+
 const SLACK_EMOJI_SIZE = 128;
 const SLACK_MAX_BYTES = 128 * 1024; // 128KB
 
 /**
+ * GIF를 FFmpeg로 128x128 리사이즈하고, 128KB 이하로 압축합니다.
+ * 색상 수를 단계적으로 줄여 용량을 맞춥니다.
+ */
+const optimizeGif = async (blob: Blob): Promise<Blob> => {
+  const ffmpeg = await getFFmpeg();
+
+  const origin = window.location.origin;
+  const utilUrl = `${origin}/ffmpeg/util/index.js`;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { fetchFile } = (await import(/* webpackIgnore: true */ utilUrl)) as any;
+
+  await ffmpeg.writeFile("input.gif", await fetchFile(blob));
+
+  // 색상 수를 단계적으로 줄여 128KB 이하 달성
+  for (const colors of [256, 128, 64, 32]) {
+    await ffmpeg.exec([
+      "-i",
+      "input.gif",
+      "-vf",
+      `scale=${SLACK_EMOJI_SIZE}:${SLACK_EMOJI_SIZE}:force_original_aspect_ratio=increase,crop=${SLACK_EMOJI_SIZE}:${SLACK_EMOJI_SIZE},split[s0][s1];[s0]palettegen=max_colors=${colors}[p];[s1][p]paletteuse=dither=bayer`,
+      "-loop",
+      "0",
+      "-y",
+      "output.gif",
+    ]);
+
+    const data = await ffmpeg.readFile("output.gif");
+    const optimized = new Blob([new Uint8Array(data as Uint8Array)], {
+      type: "image/gif",
+    });
+
+    if (optimized.size <= SLACK_MAX_BYTES) {
+      await ffmpeg.deleteFile("input.gif");
+      await ffmpeg.deleteFile("output.gif");
+      return optimized;
+    }
+  }
+
+  // 최소 색상으로도 초과 시 마지막 결과 반환
+  const data = await ffmpeg.readFile("output.gif");
+  await ffmpeg.deleteFile("input.gif");
+  await ffmpeg.deleteFile("output.gif");
+  return new Blob([new Uint8Array(data as Uint8Array)], { type: "image/gif" });
+};
+
+/**
  * 다운로드 시 이미지를 Slack 이모지 규격(128x128, 128KB 이하)으로 최적화합니다.
  * - PNG/JPEG/WebP: Canvas로 128x128 리사이즈 → 128KB 초과 시 quality 단계적 압축
- * - GIF: 128KB 이하면 원본, 초과 시 null 반환 (호출부에서 처리)
+ * - GIF: FFmpeg로 128x128 리사이즈 + 색상 수 조절로 128KB 이하 압축
  */
-export const optimizeForSlack = async (
-  blob: Blob
-): Promise<{ blob: Blob; extension: string; skipped?: boolean }> => {
-  // GIF는 클라이언트에서 프레임 단위 리사이즈가 어려우므로
-  // 용량만 체크하고, 초과 시 skipped 플래그로 알림
+export const optimizeForSlack = async (blob: Blob): Promise<{ blob: Blob; extension: string }> => {
+  // GIF → FFmpeg로 리사이즈 + 압축
   if (blob.type === "image/gif") {
-    if (blob.size <= SLACK_MAX_BYTES) {
-      return { blob, extension: "gif" };
-    }
-    return { blob, extension: "gif", skipped: true };
+    const optimized = await optimizeGif(blob);
+    return { blob: optimized, extension: "gif" };
   }
 
   // PNG/JPEG/WebP → 128x128 리사이즈

--- a/src/lib/video-to-gif.ts
+++ b/src/lib/video-to-gif.ts
@@ -36,7 +36,7 @@ export const getVideoDuration = (file: File): Promise<number> =>
 let ffmpegInstance: any = null;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const getFFmpeg = async (onProgress?: (progress: number) => void): Promise<any> => {
+export const getFFmpeg = async (onProgress?: (progress: number) => void): Promise<any> => {
   if (ffmpegInstance?.loaded) {
     if (onProgress) {
       ffmpegInstance.on("progress", ({ progress }: { progress: number }) =>


### PR DESCRIPTION
## Summary
- GIF 다운로드 시 FFmpeg로 128x128 리사이즈 + 128KB 이하 압축 처리 추가
- 색상 수 단계적 감소(256→128→64→32)로 용량 최적화
- 기존 `getFFmpeg`를 export하여 재사용

## Related Issue
Closes #40

## Changes
| 파일 | 변경 |
|------|------|
| src/lib/optimize-for-slack.ts | FFmpeg 기반 GIF 리사이즈/압축 로직 추가 |
| src/lib/video-to-gif.ts | getFFmpeg export 처리 |
| src/hooks/use-emoji-download.ts | skipped 경고 toast 제거, sonner import 제거 |

## Test
- [ ] GIF 이모지 다운로드 시 128x128 리사이즈 확인
- [ ] 128KB 초과 GIF 다운로드 시 압축 동작 확인
- [ ] PNG/JPEG 이모지 다운로드 기존 동작 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)