### PR TITLE
chore(seo): Google Search Console 소유권 인증 메타태그 추가 (#44)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -44,6 +44,9 @@ export const metadata: Metadata = {
     title: "Slack Emo - Slack 커스텀 이모지 공유 플랫폼",
     description: "Slack 워크스페이스를 위한 커스텀 이모지를 찾고, 다운로드하고, 공유하세요.",
   },
+  verification: {
+    google: "jf7pPSbqLjloi6FUTeRrXCGEpiXAB5wninqUIGCNmkk",
+  },
   alternates: {
     canonical: "https://slack-emo.vercel.app",
   },


### PR DESCRIPTION
## Summary
- Google Search Console 소유권 인증을 위한 `verification` 메타태그 추가

## Related Issue
Closes #44

## Changes
| 파일 | 변경 |
|------|------|
| src/app/layout.tsx | metadata에 `verification.google` 추가 |

## Test
- [ ] 배포 후 HTML에 `<meta name="google-site-verification">` 태그 확인
- [ ] Google Search Console에서 소유권 인증 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)