### PR TITLE
feat(seo): OG 이미지, JSON-LD, 한글 키워드, 네이버 인증 (#48)

### DIFF
--- a/src/app/(main)/category/[slug]/page.tsx
+++ b/src/app/(main)/category/[slug]/page.tsx
@@ -20,13 +20,21 @@ export const generateMetadata = async ({ params }: Props): Promise<Metadata> => 
 
   const name = category?.name ?? slug;
   const description =
-    category?.description ?? `${name} 카테고리의 Slack 커스텀 이모지를 다운로드하세요.`;
+    category?.description ??
+    `${name} 슬랙 이모지 & 이모티콘 무료 다운로드. ${name} 카테고리의 커스텀 이모지를 Slack에 바로 추가하세요.`;
 
   return {
-    title: `${name} 이모지`,
+    title: `${name} 슬랙 이모지 무료 다운로드`,
     description,
+    keywords: [
+      `${name} 슬랙 이모지`,
+      `${name} 이모티콘`,
+      `슬랙 ${name} 이모지`,
+      "슬랙 이모지 다운로드",
+      "슬랙 커스텀 이모지",
+    ],
     openGraph: {
-      title: `${name} 이모지 | Slack Emo`,
+      title: `${name} 슬랙 이모지 | Slack Emo`,
       description,
       url: `https://slack-emo.vercel.app/category/${slug}`,
     },

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,25 +15,36 @@ const notoSansKR = Noto_Sans_KR({
 
 export const metadata: Metadata = {
   title: {
-    default: "Slack Emo - Slack 커스텀 이모지 공유 플랫폼",
+    default: "Slack Emo - 슬랙 커스텀 이모지 무료 다운로드 & 공유",
     template: "%s | Slack Emo",
   },
   description:
-    "Slack 워크스페이스를 위한 커스텀 이모지를 찾고, 다운로드하고, 공유하세요. 다양한 카테고리의 이모지를 128x128 Slack 규격에 맞춰 바로 사용할 수 있습니다.",
+    "슬랙 워크스페이스를 위한 커스텀 이모지를 무료로 다운로드하세요. 귀여운, 웃긴, 업무용 이모티콘 모음을 128x128 Slack 규격에 맞춰 바로 사용할 수 있습니다. 슬랙 이모지 팩, 움짤 GIF 이모티콘까지 한곳에서.",
   keywords: [
-    "Slack",
-    "이모지",
-    "이모티콘",
-    "커스텀 이모지",
-    "Slack emoji",
     "슬랙 이모지",
     "슬랙 이모티콘",
+    "슬랙 커스텀 이모지",
+    "슬랙 이모지 다운로드",
+    "슬랙 이모지 무료",
+    "슬랙 이모지 모음",
+    "슬랙 이모지 팩",
+    "슬랙 이모지 만들기",
+    "슬랙 이모지 추가",
+    "슬랙 움짤 이모지",
+    "슬랙 GIF 이모지",
+    "슬랙 리액션 이모지",
+    "업무용 이모티콘",
+    "회사 슬랙 이모지",
+    "Slack emoji",
+    "Slack custom emoji",
+    "Slack 이모지",
   ],
   metadataBase: new URL("https://slack-emo.vercel.app"),
   manifest: "/manifest.json",
   openGraph: {
-    title: "Slack Emo - Slack 커스텀 이모지 공유 플랫폼",
-    description: "Slack 워크스페이스를 위한 커스텀 이모지를 찾고, 다운로드하고, 공유하세요.",
+    title: "Slack Emo - 슬랙 커스텀 이모지 무료 다운로드",
+    description:
+      "슬랙 이모지 & 이모티콘을 무료로 다운로드하세요. 귀여운, 웃긴, 업무용 이모지 모음.",
     type: "website",
     locale: "ko_KR",
     siteName: "Slack Emo",
@@ -41,11 +52,15 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "Slack Emo - Slack 커스텀 이모지 공유 플랫폼",
-    description: "Slack 워크스페이스를 위한 커스텀 이모지를 찾고, 다운로드하고, 공유하세요.",
+    title: "Slack Emo - 슬랙 커스텀 이모지 무료 다운로드",
+    description:
+      "슬랙 이모지 & 이모티콘을 무료로 다운로드하세요. 귀여운, 웃긴, 업무용 이모지 모음.",
   },
   verification: {
     google: "jf7pPSbqLjloi6FUTeRrXCGEpiXAB5wninqUIGCNmkk",
+    other: {
+      "naver-site-verification": "5d7f23e5156ef197de37534168c6955b610b2bef",
+    },
   },
   alternates: {
     canonical: "https://slack-emo.vercel.app",
@@ -69,6 +84,26 @@ export const viewport: Viewport = {
   themeColor: "#ffffff",
 };
 
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  name: "Slack Emo",
+  url: "https://slack-emo.vercel.app",
+  description: "슬랙 워크스페이스를 위한 커스텀 이모지를 무료로 다운로드하고 공유하는 플랫폼",
+  applicationCategory: "DesignApplication",
+  operatingSystem: "Web",
+  offers: {
+    "@type": "Offer",
+    price: "0",
+    priceCurrency: "KRW",
+  },
+  inLanguage: "ko",
+  author: {
+    "@type": "Organization",
+    name: "Slack Emo",
+  },
+};
+
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -77,6 +112,10 @@ export default function RootLayout({
   return (
     <html lang="ko" suppressHydrationWarning>
       <body className={`${notoSansKR.variable} font-sans antialiased`}>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
         <QueryProvider>
           <ThemeProvider
             attribute="class"

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,0 +1,56 @@
+import { ImageResponse } from "next/og";
+
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+export const runtime = "nodejs";
+export const alt = "Slack Emo - 슬랙 커스텀 이모지 무료 다운로드";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+const OgImage = async () => {
+  const iconPath = join(process.cwd(), "public", "icon-192.png");
+  const iconData = await readFile(iconPath);
+  const iconBase64 = `data:image/png;base64,${iconData.toString("base64")}`;
+
+  return new ImageResponse(
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        background: "linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%)",
+        fontFamily: "sans-serif",
+      }}
+    >
+      {}
+      <img src={iconBase64} alt="Slack Emo" width={160} height={160} style={{ marginBottom: 32 }} />
+      <div
+        style={{
+          fontSize: 64,
+          fontWeight: 700,
+          color: "#ffffff",
+          marginBottom: 16,
+        }}
+      >
+        Slack Emo
+      </div>
+      <div
+        style={{
+          fontSize: 28,
+          color: "#94a3b8",
+          textAlign: "center",
+          maxWidth: 800,
+        }}
+      >
+        슬랙 커스텀 이모지 무료 다운로드 & 공유 플랫폼
+      </div>
+    </div>,
+    { ...size }
+  );
+};
+
+export default OgImage;


### PR DESCRIPTION
## Summary
- OG 이미지 동적 생성 (1200x630, 로고 + 타이틀 + 한글 설명)
- JSON-LD WebApplication 구조화 데이터 추가
- 한글 중심 키워드 17개로 강화
- 네이버 Search Advisor 인증 메타태그 추가
- 카테고리 페이지 동적 한글 키워드 및 description 강화

## Related Issue
Closes #48

## Changes
| 파일 | 변경 |
|------|------|
| src/app/opengraph-image.tsx | OG 이미지 동적 생성 (신규) |
| src/app/layout.tsx | JSON-LD, 키워드 강화, 네이버 인증 |
| src/app/(main)/category/[slug]/page.tsx | 동적 한글 키워드 + description 강화 |

## Test
- [ ] `/opengraph-image` 접근 시 이미지 정상 생성 확인
- [ ] HTML에 JSON-LD script 태그 확인
- [ ] 네이버 Search Advisor 소유권 인증 확인
- [ ] 카카오톡/슬랙 링크 공유 시 미리보기 이미지 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)