### PR TITLE
feat(generate): 텍스트 이모지 생성기 페이지 추가

### DIFF
--- a/src/app/(main)/generate/page.tsx
+++ b/src/app/(main)/generate/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next";
+
+import { TextEmojiGenerator } from "@/components/generate";
+
+export const metadata: Metadata = {
+  title: "텍스트 이모지 생성기",
+  description:
+    "텍스트를 입력하여 Slack 커스텀 이모지를 만들어보세요. PNG, 타이핑 애니메이션 GIF 지원.",
+};
+
+export default function GeneratePage() {
+  return (
+    <div className="container mx-auto max-w-6xl px-4 py-6">
+      <div className="mb-6 text-center">
+        <h1 className="text-2xl font-bold">텍스트 이모지 생성기</h1>
+        <p className="text-muted-foreground mt-1 text-sm">
+          텍스트를 입력하고 스타일을 커스텀하여 Slack 이모지를 만들어보세요
+        </p>
+      </div>
+      <TextEmojiGenerator />
+    </div>
+  );
+}

--- a/src/components/generate/TextEmojiGenerator.tsx
+++ b/src/components/generate/TextEmojiGenerator.tsx
@@ -1,0 +1,396 @@
+"use client";
+
+import { Download, Loader2, RotateCcw } from "lucide-react";
+
+import type { GifAnimationType } from "@/lib/text-emoji-gif";
+import { canvasToPngBlob } from "@/lib/text-emoji-renderer";
+
+import { Button, Input, Label } from "@/components/ui";
+
+import { useTextEmoji } from "@/hooks/use-text-emoji";
+
+import { TextEmojiPreview } from "./TextEmojiPreview";
+
+const FONT_OPTIONS = [
+  { value: "Noto Sans KR", label: "노토 산스" },
+  { value: "serif", label: "명조체" },
+  { value: "monospace", label: "고정폭" },
+  { value: "cursive", label: "필기체" },
+] as const;
+
+const WEIGHT_OPTIONS = [
+  { value: "400", label: "보통" },
+  { value: "500", label: "중간" },
+  { value: "700", label: "굵게" },
+  { value: "900", label: "매우 굵게" },
+] as const;
+
+const ANIMATION_OPTIONS = [
+  { value: "typing", label: "타이핑" },
+  { value: "blink", label: "깜빡임" },
+] as const;
+
+const SPEED_OPTIONS = [
+  { value: 500, label: "느리게" },
+  { value: 300, label: "보통" },
+  { value: 150, label: "빠르게" },
+] as const;
+
+const COLOR_PRESETS = [
+  "#ffffff",
+  "#000000",
+  "#ef4444",
+  "#f97316",
+  "#eab308",
+  "#22c55e",
+  "#3b82f6",
+  "#8b5cf6",
+  "#ec4899",
+];
+
+const BG_PRESETS = [
+  "#4A90D9",
+  "#e74c3c",
+  "#2ecc71",
+  "#f39c12",
+  "#9b59b6",
+  "#1abc9c",
+  "#e91e63",
+  "#000000",
+  "#ffffff",
+];
+
+export const TextEmojiGenerator = () => {
+  const {
+    options,
+    outputMode,
+    gifOptions,
+    isGenerating,
+    progress,
+    canvasRef,
+    updateOption,
+    setOutputMode,
+    updateGifOption,
+    setIsGenerating,
+    setProgress,
+    resetOptions,
+  } = useTextEmoji();
+
+  const handleDownload = async () => {
+    if (!options.text.trim()) return;
+
+    setIsGenerating(true);
+    setProgress(0);
+
+    try {
+      let blob: Blob;
+      let filename: string;
+
+      if (outputMode === "gif") {
+        const { generateTextEmojiGif } = await import("@/lib/text-emoji-gif");
+        blob = await generateTextEmojiGif(options, gifOptions, setProgress);
+        filename = `${options.text.trim().slice(0, 10)}.gif`;
+      } else {
+        const canvas = canvasRef.current;
+        if (!canvas) throw new Error("Canvas를 찾을 수 없습니다");
+        blob = await canvasToPngBlob(canvas);
+        filename = `${options.text.trim().slice(0, 10)}.png`;
+      }
+
+      // 다운로드 트리거
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    } catch (error) {
+      console.error("이모지 생성 실패:", error);
+    } finally {
+      setIsGenerating(false);
+      setProgress(0);
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6">
+      {/* 미리보기 */}
+      <div className="flex justify-center">
+        <TextEmojiPreview options={options} canvasRef={canvasRef} />
+      </div>
+
+      {/* 텍스트 입력 */}
+      <div className="space-y-2">
+        <Label htmlFor="emoji-text">텍스트</Label>
+        <Input
+          id="emoji-text"
+          placeholder="이모지 텍스트 입력 (예: 확인)"
+          value={options.text}
+          onChange={(e) => updateOption("text", e.target.value)}
+          maxLength={10}
+          className="text-center text-lg"
+        />
+        <p className="text-muted-foreground text-xs">
+          줄바꿈은 Enter, 최대 10자. Slack 이모지에 적합한 짧은 텍스트를 추천합니다.
+        </p>
+      </div>
+
+      {/* 폰트 & 굵기 */}
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-2">
+          <Label>폰트</Label>
+          <select
+            value={options.fontFamily}
+            onChange={(e) => updateOption("fontFamily", e.target.value)}
+            className="border-input bg-background ring-offset-background focus-visible:ring-ring flex h-10 w-full rounded-md border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+          >
+            {FONT_OPTIONS.map((f) => (
+              <option key={f.value} value={f.value}>
+                {f.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="space-y-2">
+          <Label>굵기</Label>
+          <select
+            value={options.fontWeight}
+            onChange={(e) =>
+              updateOption("fontWeight", e.target.value as "400" | "500" | "600" | "700" | "900")
+            }
+            className="border-input bg-background ring-offset-background focus-visible:ring-ring flex h-10 w-full rounded-md border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+          >
+            {WEIGHT_OPTIONS.map((w) => (
+              <option key={w.value} value={w.value}>
+                {w.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {/* 글자색 */}
+      <div className="space-y-2">
+        <Label>글자색</Label>
+        <div className="flex items-center gap-2">
+          <div className="flex gap-1">
+            {COLOR_PRESETS.map((color) => (
+              <button
+                key={color}
+                type="button"
+                onClick={() => updateOption("textColor", color)}
+                className="h-7 w-7 rounded-full border-2 transition-transform hover:scale-110"
+                style={{
+                  backgroundColor: color,
+                  borderColor: options.textColor === color ? "#3b82f6" : "transparent",
+                }}
+              />
+            ))}
+          </div>
+          <input
+            type="color"
+            value={options.textColor}
+            onChange={(e) => updateOption("textColor", e.target.value)}
+            className="h-8 w-8 cursor-pointer rounded border-0"
+          />
+        </div>
+      </div>
+
+      {/* 배경색 */}
+      <div className="space-y-2">
+        <Label>배경</Label>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => updateOption("bgTransparent", !options.bgTransparent)}
+            className="rounded-md border px-3 py-1.5 text-xs font-medium transition-colors"
+            style={{
+              backgroundColor: options.bgTransparent ? "#3b82f6" : "transparent",
+              color: options.bgTransparent ? "#ffffff" : undefined,
+              borderColor: options.bgTransparent ? "#3b82f6" : undefined,
+            }}
+          >
+            투명
+          </button>
+          {!options.bgTransparent && (
+            <>
+              <div className="flex gap-1">
+                {BG_PRESETS.map((color) => (
+                  <button
+                    key={color}
+                    type="button"
+                    onClick={() => updateOption("bgColor", color)}
+                    className="h-7 w-7 rounded-full border-2 transition-transform hover:scale-110"
+                    style={{
+                      backgroundColor: color,
+                      borderColor: options.bgColor === color ? "#3b82f6" : "transparent",
+                    }}
+                  />
+                ))}
+              </div>
+              <input
+                type="color"
+                value={options.bgColor}
+                onChange={(e) => updateOption("bgColor", e.target.value)}
+                className="h-8 w-8 cursor-pointer rounded border-0"
+              />
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* 외곽선 */}
+      <div className="space-y-2">
+        <div className="flex items-center gap-3">
+          <Label>외곽선</Label>
+          <button
+            type="button"
+            onClick={() => updateOption("strokeEnabled", !options.strokeEnabled)}
+            className="rounded-md border px-3 py-1.5 text-xs font-medium transition-colors"
+            style={{
+              backgroundColor: options.strokeEnabled ? "#3b82f6" : "transparent",
+              color: options.strokeEnabled ? "#ffffff" : undefined,
+              borderColor: options.strokeEnabled ? "#3b82f6" : undefined,
+            }}
+          >
+            {options.strokeEnabled ? "ON" : "OFF"}
+          </button>
+        </div>
+        {options.strokeEnabled && (
+          <div className="flex items-center gap-3">
+            <div className="flex items-center gap-2">
+              <span className="text-muted-foreground text-xs">색상</span>
+              <input
+                type="color"
+                value={options.strokeColor}
+                onChange={(e) => updateOption("strokeColor", e.target.value)}
+                className="h-7 w-7 cursor-pointer rounded border-0"
+              />
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="text-muted-foreground text-xs">두께</span>
+              <input
+                type="range"
+                min={1}
+                max={8}
+                value={options.strokeWidth}
+                onChange={(e) => updateOption("strokeWidth", Number(e.target.value))}
+                className="w-24"
+              />
+              <span className="text-muted-foreground text-xs">{options.strokeWidth}px</span>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* 출력 모드 */}
+      <div className="space-y-2">
+        <Label>출력 형식</Label>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={() => setOutputMode("png")}
+            className="flex-1 rounded-md border py-2 text-sm font-medium transition-colors"
+            style={{
+              backgroundColor: outputMode === "png" ? "#3b82f6" : "transparent",
+              color: outputMode === "png" ? "#ffffff" : undefined,
+              borderColor: outputMode === "png" ? "#3b82f6" : undefined,
+            }}
+          >
+            정적 PNG
+          </button>
+          <button
+            type="button"
+            onClick={() => setOutputMode("gif")}
+            className="flex-1 rounded-md border py-2 text-sm font-medium transition-colors"
+            style={{
+              backgroundColor: outputMode === "gif" ? "#3b82f6" : "transparent",
+              color: outputMode === "gif" ? "#ffffff" : undefined,
+              borderColor: outputMode === "gif" ? "#3b82f6" : undefined,
+            }}
+          >
+            애니메이션 GIF
+          </button>
+        </div>
+      </div>
+
+      {/* GIF 옵션 */}
+      {outputMode === "gif" && (
+        <div className="bg-muted/50 space-y-3 rounded-lg p-4">
+          <div className="space-y-2">
+            <Label>애니메이션</Label>
+            <div className="flex gap-2">
+              {ANIMATION_OPTIONS.map((anim) => (
+                <button
+                  key={anim.value}
+                  type="button"
+                  onClick={() => updateGifOption("animationType", anim.value as GifAnimationType)}
+                  className="rounded-md border px-3 py-1.5 text-sm transition-colors"
+                  style={{
+                    backgroundColor:
+                      gifOptions.animationType === anim.value ? "#3b82f6" : "transparent",
+                    color: gifOptions.animationType === anim.value ? "#ffffff" : undefined,
+                    borderColor: gifOptions.animationType === anim.value ? "#3b82f6" : undefined,
+                  }}
+                >
+                  {anim.label}
+                </button>
+              ))}
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label>속도</Label>
+            <div className="flex gap-2">
+              {SPEED_OPTIONS.map((speed) => (
+                <button
+                  key={speed.value}
+                  type="button"
+                  onClick={() => updateGifOption("charDelay", speed.value)}
+                  className="rounded-md border px-3 py-1.5 text-sm transition-colors"
+                  style={{
+                    backgroundColor:
+                      gifOptions.charDelay === speed.value ? "#3b82f6" : "transparent",
+                    color: gifOptions.charDelay === speed.value ? "#ffffff" : undefined,
+                    borderColor: gifOptions.charDelay === speed.value ? "#3b82f6" : undefined,
+                  }}
+                >
+                  {speed.label}
+                </button>
+              ))}
+            </div>
+          </div>
+          <p className="text-muted-foreground text-xs">
+            GIF 생성 시 FFmpeg를 사용합니다. 첫 사용 시 로딩에 시간이 걸릴 수 있습니다.
+          </p>
+        </div>
+      )}
+
+      {/* 액션 버튼 */}
+      <div className="flex gap-3">
+        <Button
+          onClick={handleDownload}
+          disabled={!options.text.trim() || isGenerating}
+          className="flex-1"
+          size="lg"
+        >
+          {isGenerating ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              생성 중... {progress > 0 ? `${progress}%` : ""}
+            </>
+          ) : (
+            <>
+              <Download className="mr-2 h-4 w-4" />
+              다운로드 ({outputMode.toUpperCase()})
+            </>
+          )}
+        </Button>
+        <Button variant="outline" size="lg" onClick={resetOptions}>
+          <RotateCcw className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/src/components/generate/TextEmojiPreview.tsx
+++ b/src/components/generate/TextEmojiPreview.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+import { CANVAS_SIZE, renderTextEmoji } from "@/lib/text-emoji-renderer";
+import type { TextEmojiOptions } from "@/lib/text-emoji-renderer";
+
+type TextEmojiPreviewProps = {
+  options: TextEmojiOptions;
+  canvasRef: React.RefObject<HTMLCanvasElement | null>;
+};
+
+export const TextEmojiPreview = ({ options, canvasRef }: TextEmojiPreviewProps) => {
+  const fontReadyRef = useRef(false);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const draw = () => {
+      renderTextEmoji(ctx, options);
+    };
+
+    if (fontReadyRef.current) {
+      draw();
+    } else {
+      document.fonts.ready.then(() => {
+        fontReadyRef.current = true;
+        draw();
+      });
+    }
+  }, [options, canvasRef]);
+
+  return (
+    <div className="flex flex-col items-center gap-3">
+      <div
+        className="relative rounded-lg border-2 border-dashed border-gray-300 p-2 dark:border-gray-600"
+        style={{
+          background: options.bgTransparent
+            ? "repeating-conic-gradient(#d1d5db 0% 25%, transparent 0% 50%) 50% / 16px 16px"
+            : undefined,
+        }}
+      >
+        <canvas
+          ref={canvasRef}
+          width={CANVAS_SIZE}
+          height={CANVAS_SIZE}
+          className="h-32 w-32"
+          style={{ imageRendering: "auto" }}
+        />
+      </div>
+      <p className="text-muted-foreground text-xs">128 × 128 px</p>
+    </div>
+  );
+};

--- a/src/components/generate/index.ts
+++ b/src/components/generate/index.ts
@@ -1,0 +1,2 @@
+export * from "./TextEmojiGenerator";
+export * from "./TextEmojiPreview";

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -4,7 +4,7 @@ import { useTheme } from "next-themes";
 import Image from "next/image";
 import Link from "next/link";
 
-import { LogOut, Moon, Search, Sun } from "lucide-react";
+import { LogOut, Moon, Search, Sun, Type } from "lucide-react";
 
 import { EmojiUploadDialog } from "@/components/emoji";
 import { useSearchContext } from "@/components/search-provider";
@@ -64,6 +64,14 @@ export const Header = () => {
               />
             </div>
           </div>
+
+          {/* Generate Button */}
+          <Link href="/generate">
+            <Button variant="ghost" size="icon" title="텍스트 이모지 만들기">
+              <Type className="h-5 w-5" />
+              <span className="sr-only">텍스트 이모지 생성</span>
+            </Button>
+          </Link>
 
           {/* Upload Button - Only for logged in users */}
           {user && <EmojiUploadDialog />}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -5,3 +5,4 @@ export * from "./use-emojis";
 export * from "./use-emoji-download";
 export * from "./use-emoji-upload-form";
 export * from "./use-filtered-emojis";
+export * from "./use-text-emoji";

--- a/src/hooks/use-text-emoji.ts
+++ b/src/hooks/use-text-emoji.ts
@@ -1,0 +1,69 @@
+import { useCallback, useRef, useState } from "react";
+
+import type { GifAnimationType, GifOptions } from "@/lib/text-emoji-gif";
+import type { TextEmojiOptions } from "@/lib/text-emoji-renderer";
+
+type OutputMode = "png" | "gif";
+
+const DEFAULT_OPTIONS: TextEmojiOptions = {
+  text: "",
+  fontFamily: "Noto Sans KR",
+  fontWeight: "700",
+  textColor: "#ffffff",
+  bgColor: "#4A90D9",
+  bgTransparent: false,
+  strokeEnabled: true,
+  strokeColor: "#000000",
+  strokeWidth: 3,
+};
+
+const DEFAULT_GIF_OPTIONS: GifOptions = {
+  animationType: "typing" as GifAnimationType,
+  charDelay: 300,
+};
+
+export const useTextEmoji = () => {
+  const [options, setOptions] = useState<TextEmojiOptions>(DEFAULT_OPTIONS);
+  const [outputMode, setOutputMode] = useState<OutputMode>("png");
+  const [gifOptions, setGifOptions] = useState<GifOptions>(DEFAULT_GIF_OPTIONS);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  const updateOption = useCallback(
+    <K extends keyof TextEmojiOptions>(key: K, value: TextEmojiOptions[K]) => {
+      setOptions((prev) => ({ ...prev, [key]: value }));
+    },
+    []
+  );
+
+  const updateGifOption = useCallback(
+    <K extends keyof GifOptions>(key: K, value: GifOptions[K]) => {
+      setGifOptions((prev) => ({ ...prev, [key]: value }));
+    },
+    []
+  );
+
+  const resetOptions = useCallback(() => {
+    setOptions(DEFAULT_OPTIONS);
+    setGifOptions(DEFAULT_GIF_OPTIONS);
+    setOutputMode("png");
+  }, []);
+
+  return {
+    options,
+    outputMode,
+    gifOptions,
+    isGenerating,
+    progress,
+    canvasRef,
+    setOptions,
+    updateOption,
+    setOutputMode,
+    setGifOptions,
+    updateGifOption,
+    setIsGenerating,
+    setProgress,
+    resetOptions,
+  };
+};

--- a/src/lib/text-emoji-gif.ts
+++ b/src/lib/text-emoji-gif.ts
@@ -1,0 +1,125 @@
+import { CANVAS_SIZE, renderTextEmoji } from "./text-emoji-renderer";
+import type { TextEmojiOptions } from "./text-emoji-renderer";
+import { getFFmpeg } from "./video-to-gif";
+
+export type GifAnimationType = "typing" | "bounce" | "fade" | "blink";
+
+export type GifOptions = {
+  animationType: GifAnimationType;
+  /** 글자당 딜레이 (ms) */
+  charDelay: number;
+};
+
+/**
+ * 타이핑 애니메이션: 한 글자씩 등장하는 프레임 텍스트 목록 생성
+ */
+const generateTypingFrames = (text: string): string[] => {
+  const chars = [...text]; // 한글 자모 분리 방지
+  const frames: string[] = [];
+
+  for (let i = 1; i <= chars.length; i++) {
+    frames.push(chars.slice(0, i).join(""));
+  }
+
+  // 마지막 프레임(완성 텍스트)을 추가로 유지
+  frames.push(text);
+  frames.push(text);
+
+  return frames;
+};
+
+/**
+ * 깜빡임 애니메이션: 텍스트 → 빈 화면 → 텍스트 반복
+ */
+const generateBlinkFrames = (text: string): string[] => [text, "", text, "", text, text];
+
+/**
+ * 프레임 텍스트 목록 생성 (애니메이션 타입별)
+ */
+const generateFrameTexts = (text: string, animationType: GifAnimationType): string[] => {
+  switch (animationType) {
+    case "typing":
+      return generateTypingFrames(text);
+    case "blink":
+      return generateBlinkFrames(text);
+    case "bounce":
+    case "fade":
+    default:
+      return generateTypingFrames(text);
+  }
+};
+
+/**
+ * 텍스트 이모지 → 애니메이션 GIF 생성
+ */
+export const generateTextEmojiGif = async (
+  emojiOptions: TextEmojiOptions,
+  gifOptions: GifOptions,
+  onProgress?: (progress: number) => void
+): Promise<Blob> => {
+  const frameTexts = generateFrameTexts(emojiOptions.text, gifOptions.animationType);
+  const frameCount = frameTexts.length;
+
+  onProgress?.(5);
+
+  // 각 프레임을 PNG로 렌더링
+  const canvas = new OffscreenCanvas(CANVAS_SIZE, CANVAS_SIZE);
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("Canvas 2D 컨텍스트를 생성할 수 없습니다");
+
+  // 폰트 로딩 대기
+  await document.fonts.ready;
+
+  const framePngs: Uint8Array[] = [];
+
+  for (let i = 0; i < frameCount; i++) {
+    renderTextEmoji(ctx, emojiOptions, frameTexts[i]);
+    const blob = await canvas.convertToBlob({ type: "image/png" });
+    const buffer = await blob.arrayBuffer();
+    framePngs.push(new Uint8Array(buffer));
+    onProgress?.(5 + Math.round((i / frameCount) * 30));
+  }
+
+  onProgress?.(40);
+
+  // FFmpeg로 프레임들을 GIF로 결합
+  const ffmpeg = await getFFmpeg((p) => {
+    onProgress?.(40 + Math.round(p * 0.5));
+  });
+
+  // 프레임 파일 쓰기
+  for (let i = 0; i < framePngs.length; i++) {
+    await ffmpeg.writeFile(`frame_${String(i).padStart(3, "0")}.png`, framePngs[i]);
+  }
+
+  // fps 계산: charDelay ms당 1프레임
+  const fps = Math.max(1, Math.round(1000 / gifOptions.charDelay));
+
+  // 프레임 → GIF 변환 (palette 생성 + 적용)
+  await ffmpeg.exec([
+    "-framerate",
+    String(fps),
+    "-i",
+    "frame_%03d.png",
+    "-vf",
+    `split[s0][s1];[s0]palettegen=max_colors=128[p];[s1][p]paletteuse=dither=bayer`,
+    "-loop",
+    "0",
+    "output.gif",
+  ]);
+
+  onProgress?.(95);
+
+  const data = await ffmpeg.readFile("output.gif");
+  const gifBlob = new Blob([new Uint8Array(data as Uint8Array)], { type: "image/gif" });
+
+  // 정리
+  for (let i = 0; i < framePngs.length; i++) {
+    await ffmpeg.deleteFile(`frame_${String(i).padStart(3, "0")}.png`);
+  }
+  await ffmpeg.deleteFile("output.gif");
+
+  onProgress?.(100);
+
+  return gifBlob;
+};

--- a/src/lib/text-emoji-renderer.ts
+++ b/src/lib/text-emoji-renderer.ts
@@ -1,0 +1,130 @@
+const CANVAS_SIZE = 128;
+const PADDING = 6;
+const DRAWABLE_SIZE = CANVAS_SIZE - PADDING * 2;
+
+export type TextEmojiOptions = {
+  text: string;
+  fontFamily: string;
+  fontWeight: "400" | "500" | "600" | "700" | "900";
+  textColor: string;
+  bgColor: string;
+  bgTransparent: boolean;
+  strokeEnabled: boolean;
+  strokeColor: string;
+  strokeWidth: number;
+};
+
+/** 줄바꿈(\n) 기준으로 분리한 텍스트 줄 */
+const getLines = (text: string): string[] => {
+  const lines = text.split("\n").filter((l) => l.length > 0);
+  return lines.length > 0 ? lines : [""];
+};
+
+/** 주어진 fontSize에서 모든 줄이 캔버스 안에 들어가는지 확인 */
+const measureFit = (
+  ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
+  lines: string[],
+  fontFamily: string,
+  fontWeight: string,
+  fontSize: number
+): boolean => {
+  ctx.font = `${fontWeight} ${fontSize}px '${fontFamily}', 'Noto Sans KR', sans-serif`;
+
+  const maxWidth = Math.max(...lines.map((line) => ctx.measureText(line).width));
+  const lineHeight = fontSize * 1.2;
+  const totalHeight = lineHeight * lines.length;
+
+  return maxWidth <= DRAWABLE_SIZE && totalHeight <= DRAWABLE_SIZE;
+};
+
+/** 텍스트가 캔버스에 맞는 최대 fontSize를 이진 탐색 */
+const findBestFontSize = (
+  ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
+  lines: string[],
+  fontFamily: string,
+  fontWeight: string
+): number => {
+  let lo = 8;
+  let hi = 120;
+
+  while (lo < hi) {
+    const mid = Math.ceil((lo + hi) / 2);
+    if (measureFit(ctx, lines, fontFamily, fontWeight, mid)) {
+      lo = mid;
+    } else {
+      hi = mid - 1;
+    }
+  }
+
+  return lo;
+};
+
+/**
+ * Canvas에 텍스트 이모지를 렌더링합니다.
+ * displayText를 전달하면 부분 텍스트(GIF 프레임용)를 렌더링합니다.
+ */
+export const renderTextEmoji = (
+  ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
+  options: TextEmojiOptions,
+  displayText?: string
+): void => {
+  const text = displayText ?? options.text;
+  const lines = getLines(text);
+
+  // 배경
+  ctx.clearRect(0, 0, CANVAS_SIZE, CANVAS_SIZE);
+  if (!options.bgTransparent) {
+    ctx.fillStyle = options.bgColor;
+    ctx.fillRect(0, 0, CANVAS_SIZE, CANVAS_SIZE);
+  }
+
+  if (!text.trim()) return;
+
+  // 자동 폰트 사이즈 계산 (전체 텍스트 기준으로 크기 결정)
+  const fullLines = getLines(options.text);
+  const fontSize = findBestFontSize(ctx, fullLines, options.fontFamily, options.fontWeight);
+  const font = `${options.fontWeight} ${fontSize}px '${options.fontFamily}', 'Noto Sans KR', sans-serif`;
+
+  ctx.font = font;
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+
+  const lineHeight = fontSize * 1.2;
+  const totalHeight = lineHeight * lines.length;
+  const startY = (CANVAS_SIZE - totalHeight) / 2 + lineHeight / 2;
+
+  // 외곽선
+  if (options.strokeEnabled && options.strokeWidth > 0) {
+    ctx.strokeStyle = options.strokeColor;
+    ctx.lineWidth = options.strokeWidth * 2;
+    ctx.lineJoin = "round";
+    ctx.miterLimit = 2;
+
+    lines.forEach((line, i) => {
+      ctx.strokeText(line, CANVAS_SIZE / 2, startY + i * lineHeight);
+    });
+  }
+
+  // 텍스트
+  ctx.fillStyle = options.textColor;
+  lines.forEach((line, i) => {
+    ctx.fillText(line, CANVAS_SIZE / 2, startY + i * lineHeight);
+  });
+};
+
+/** Canvas를 PNG Blob으로 내보냅니다 */
+export const canvasToPngBlob = async (
+  canvas: HTMLCanvasElement | OffscreenCanvas
+): Promise<Blob> => {
+  if (canvas instanceof OffscreenCanvas) {
+    return canvas.convertToBlob({ type: "image/png" });
+  }
+  return new Promise((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (blob) resolve(blob);
+      else reject(new Error("PNG 변환 실패"));
+    }, "image/png");
+  });
+};
+
+export { CANVAS_SIZE };


### PR DESCRIPTION
## Summary
- 텍스트 입력 → 128x128 Slack 커스텀 이모지 생성 (PNG/GIF)
- Canvas API 기반 실시간 미리보기, 폰트/색상/외곽선 커스터마이징
- FFmpeg 활용 타이핑/깜빡임 애니메이션 GIF 생성
- Header에 /generate 네비게이션 링크 추가

## Related Issue
Closes #50

## Changes
| 그룹 | 파일 | 변경 |
|------|------|------|
| 코어 로직 | `src/lib/text-emoji-renderer.ts` | Canvas 렌더링 (자동 폰트 크기, 외곽선, 멀티라인) |
| 코어 로직 | `src/lib/text-emoji-gif.ts` | GIF 프레임 생성 + FFmpeg 결합 |
| 훅 | `src/hooks/use-text-emoji.ts` | 생성기 상태 관리 |
| 컴포넌트 | `src/components/generate/TextEmojiGenerator.tsx` | 메인 UI (옵션 패널 + 다운로드) |
| 컴포넌트 | `src/components/generate/TextEmojiPreview.tsx` | 실시간 Canvas 미리보기 |
| 페이지 | `src/app/(main)/generate/page.tsx` | /generate 라우트 |
| 레이아웃 | `src/components/layout/Header.tsx` | Type 아이콘 네비게이션 추가 |

## Test
- [ ] `/generate` 페이지 접근 확인
- [ ] 텍스트 입력 → 실시간 미리보기 렌더링
- [ ] PNG 다운로드 (128x128)
- [ ] GIF 다운로드 (타이핑 애니메이션)
- [ ] 모바일 반응형 레이아웃

🤖 Generated with [Claude Code](https://claude.com/claude-code)