### PR TITLE
fix(generate): 폰트 버그 수정, 애니메이션 정리, shadcn Select

### DIFF
--- a/src/components/generate/TextEmojiGenerator.tsx
+++ b/src/components/generate/TextEmojiGenerator.tsx
@@ -2,10 +2,16 @@
 
 import { Download, Loader2, RotateCcw } from "lucide-react";
 
-import type { GifAnimationType } from "@/lib/text-emoji-gif";
 import { canvasToPngBlob } from "@/lib/text-emoji-renderer";
 
 import { Button, Input, Label } from "@/components/ui";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 
 import { useTextEmoji } from "@/hooks/use-text-emoji";
 
@@ -23,11 +29,6 @@ const WEIGHT_OPTIONS = [
   { value: "500", label: "중간" },
   { value: "700", label: "굵게" },
   { value: "900", label: "매우 굵게" },
-] as const;
-
-const ANIMATION_OPTIONS = [
-  { value: "typing", label: "타이핑" },
-  { value: "blink", label: "깜빡임" },
 ] as const;
 
 const SPEED_OPTIONS = [
@@ -141,33 +142,41 @@ export const TextEmojiGenerator = () => {
       <div className="grid grid-cols-2 gap-4">
         <div className="space-y-2">
           <Label>폰트</Label>
-          <select
+          <Select
             value={options.fontFamily}
-            onChange={(e) => updateOption("fontFamily", e.target.value)}
-            className="border-input bg-background ring-offset-background focus-visible:ring-ring flex h-10 w-full rounded-md border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+            onValueChange={(value) => updateOption("fontFamily", value)}
           >
-            {FONT_OPTIONS.map((f) => (
-              <option key={f.value} value={f.value}>
-                {f.label}
-              </option>
-            ))}
-          </select>
+            <SelectTrigger className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {FONT_OPTIONS.map((f) => (
+                <SelectItem key={f.value} value={f.value}>
+                  {f.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </div>
         <div className="space-y-2">
           <Label>굵기</Label>
-          <select
+          <Select
             value={options.fontWeight}
-            onChange={(e) =>
-              updateOption("fontWeight", e.target.value as "400" | "500" | "600" | "700" | "900")
+            onValueChange={(value) =>
+              updateOption("fontWeight", value as "400" | "500" | "600" | "700" | "900")
             }
-            className="border-input bg-background ring-offset-background focus-visible:ring-ring flex h-10 w-full rounded-md border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
           >
-            {WEIGHT_OPTIONS.map((w) => (
-              <option key={w.value} value={w.value}>
-                {w.label}
-              </option>
-            ))}
-          </select>
+            <SelectTrigger className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {WEIGHT_OPTIONS.map((w) => (
+                <SelectItem key={w.value} value={w.value}>
+                  {w.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </div>
       </div>
 
@@ -316,32 +325,11 @@ export const TextEmojiGenerator = () => {
         </div>
       </div>
 
-      {/* GIF 옵션 */}
+      {/* GIF 옵션 — 타이핑 속도만 */}
       {outputMode === "gif" && (
         <div className="bg-muted/50 space-y-3 rounded-lg p-4">
           <div className="space-y-2">
-            <Label>애니메이션</Label>
-            <div className="flex gap-2">
-              {ANIMATION_OPTIONS.map((anim) => (
-                <button
-                  key={anim.value}
-                  type="button"
-                  onClick={() => updateGifOption("animationType", anim.value as GifAnimationType)}
-                  className="rounded-md border px-3 py-1.5 text-sm transition-colors"
-                  style={{
-                    backgroundColor:
-                      gifOptions.animationType === anim.value ? "#3b82f6" : "transparent",
-                    color: gifOptions.animationType === anim.value ? "#ffffff" : undefined,
-                    borderColor: gifOptions.animationType === anim.value ? "#3b82f6" : undefined,
-                  }}
-                >
-                  {anim.label}
-                </button>
-              ))}
-            </div>
-          </div>
-          <div className="space-y-2">
-            <Label>속도</Label>
+            <Label>타이핑 속도</Label>
             <div className="flex gap-2">
               {SPEED_OPTIONS.map((speed) => (
                 <button
@@ -362,7 +350,7 @@ export const TextEmojiGenerator = () => {
             </div>
           </div>
           <p className="text-muted-foreground text-xs">
-            GIF 생성 시 FFmpeg를 사용합니다. 첫 사용 시 로딩에 시간이 걸릴 수 있습니다.
+            한 글자씩 순서대로 나타나는 타이핑 애니메이션 GIF를 생성합니다.
           </p>
         </div>
       )}

--- a/src/hooks/use-text-emoji.ts
+++ b/src/hooks/use-text-emoji.ts
@@ -1,6 +1,6 @@
 import { useCallback, useRef, useState } from "react";
 
-import type { GifAnimationType, GifOptions } from "@/lib/text-emoji-gif";
+import type { GifOptions } from "@/lib/text-emoji-gif";
 import type { TextEmojiOptions } from "@/lib/text-emoji-renderer";
 
 type OutputMode = "png" | "gif";
@@ -18,7 +18,6 @@ const DEFAULT_OPTIONS: TextEmojiOptions = {
 };
 
 const DEFAULT_GIF_OPTIONS: GifOptions = {
-  animationType: "typing" as GifAnimationType,
   charDelay: 300,
 };
 

--- a/src/lib/text-emoji-gif.ts
+++ b/src/lib/text-emoji-gif.ts
@@ -2,10 +2,7 @@ import { CANVAS_SIZE, renderTextEmoji } from "./text-emoji-renderer";
 import type { TextEmojiOptions } from "./text-emoji-renderer";
 import { getFFmpeg } from "./video-to-gif";
 
-export type GifAnimationType = "typing" | "bounce" | "fade" | "blink";
-
 export type GifOptions = {
-  animationType: GifAnimationType;
   /** 글자당 딜레이 (ms) */
   charDelay: number;
 };
@@ -29,35 +26,14 @@ const generateTypingFrames = (text: string): string[] => {
 };
 
 /**
- * 깜빡임 애니메이션: 텍스트 → 빈 화면 → 텍스트 반복
- */
-const generateBlinkFrames = (text: string): string[] => [text, "", text, "", text, text];
-
-/**
- * 프레임 텍스트 목록 생성 (애니메이션 타입별)
- */
-const generateFrameTexts = (text: string, animationType: GifAnimationType): string[] => {
-  switch (animationType) {
-    case "typing":
-      return generateTypingFrames(text);
-    case "blink":
-      return generateBlinkFrames(text);
-    case "bounce":
-    case "fade":
-    default:
-      return generateTypingFrames(text);
-  }
-};
-
-/**
- * 텍스트 이모지 → 애니메이션 GIF 생성
+ * 텍스트 이모지 → 타이핑 애니메이션 GIF 생성
  */
 export const generateTextEmojiGif = async (
   emojiOptions: TextEmojiOptions,
   gifOptions: GifOptions,
   onProgress?: (progress: number) => void
 ): Promise<Blob> => {
-  const frameTexts = generateFrameTexts(emojiOptions.text, gifOptions.animationType);
+  const frameTexts = generateTypingFrames(emojiOptions.text);
   const frameCount = frameTexts.length;
 
   onProgress?.(5);

--- a/src/lib/text-emoji-renderer.ts
+++ b/src/lib/text-emoji-renderer.ts
@@ -20,6 +20,14 @@ const getLines = (text: string): string[] => {
   return lines.length > 0 ? lines : [""];
 };
 
+/** generic 폰트는 따옴표 없이, 커스텀 폰트는 따옴표로 감싼다 */
+const GENERIC_FONTS = new Set(["serif", "sans-serif", "monospace", "cursive", "fantasy"]);
+
+const formatFontFamily = (fontFamily: string): string => {
+  if (GENERIC_FONTS.has(fontFamily)) return fontFamily;
+  return `'${fontFamily}'`;
+};
+
 /** 주어진 fontSize에서 모든 줄이 캔버스 안에 들어가는지 확인 */
 const measureFit = (
   ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
@@ -28,7 +36,7 @@ const measureFit = (
   fontWeight: string,
   fontSize: number
 ): boolean => {
-  ctx.font = `${fontWeight} ${fontSize}px '${fontFamily}', 'Noto Sans KR', sans-serif`;
+  ctx.font = `${fontWeight} ${fontSize}px ${formatFontFamily(fontFamily)}, sans-serif`;
 
   const maxWidth = Math.max(...lines.map((line) => ctx.measureText(line).width));
   const lineHeight = fontSize * 1.2;
@@ -83,7 +91,7 @@ export const renderTextEmoji = (
   // 자동 폰트 사이즈 계산 (전체 텍스트 기준으로 크기 결정)
   const fullLines = getLines(options.text);
   const fontSize = findBestFontSize(ctx, fullLines, options.fontFamily, options.fontWeight);
-  const font = `${options.fontWeight} ${fontSize}px '${options.fontFamily}', 'Noto Sans KR', sans-serif`;
+  const font = `${options.fontWeight} ${fontSize}px ${formatFontFamily(options.fontFamily)}, sans-serif`;
 
   ctx.font = font;
   ctx.textAlign = "center";


### PR DESCRIPTION
## Summary
- Canvas generic 폰트(serif, monospace 등) 변경 안 되는 버그 수정
- 불필요한 애니메이션 타입 제거, 타이핑(한 글자씩)만 유지
- system select → shadcn Select 컴포넌트 교체

## Related Issue
Closes #52

## Changes
| 그룹 | 파일 | 변경 |
|------|------|------|
| 코어 로직 | `text-emoji-renderer.ts` | `formatFontFamily()` 추가 — generic 폰트 따옴표 제거 |
| 코어 로직 | `text-emoji-gif.ts` | `GifAnimationType`, `generateBlinkFrames` 등 삭제 |
| 훅 | `use-text-emoji.ts` | `animationType` 상태 제거 |
| 컴포넌트 | `TextEmojiGenerator.tsx` | shadcn Select 적용, 애니메이션 선택 UI 제거 |

## Test
- [ ] 폰트 변경 시 미리보기에 즉시 반영 확인
- [ ] GIF 다운로드 시 타이핑 애니메이션 정상 동작
- [ ] shadcn Select 드롭다운 정상 렌더링

🤖 Generated with [Claude Code](https://claude.com/claude-code)